### PR TITLE
Browsing of "true" hierarchy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 node_modules
 dist
+.project
 
 .DS_Store

--- a/lib/server.js
+++ b/lib/server.js
@@ -114,15 +114,15 @@ app.get('/hierarchy', function (req, res) {
    
    let node = getNodeByPath(req.query.path);
    
-   var res = [];
+   let nodes = [];
    
    if (node) 
       for (var k=0;k<node.nodes.length;++k)
-         res.push({name: node.nodes[k].name, type: node.nodes[k].type });
+         nodes.push({ _name: node.nodes[k].name, type: node.nodes[k].type });
    
-   console.log('Sending h reply len=' + res.length);
+   console.log('Sending h reply len=' + nodes.length);
    
-   res.write(JSON.stringify(res, 2, "\t"));
+   res.write(JSON.stringify(nodes, 2, "\t"));
    res.contentType = "text/json";
    res.end();
 });

--- a/lib/server.js
+++ b/lib/server.js
@@ -112,12 +112,34 @@ app.use(compression({
 	}
 }));
 
+function doSorting(nodes, sort) {
+   if (!sort) return nodes;
+   
+   var newnodes = [];
+   
+   newnodes = newnodes.concat(nodes);
+   
+   var func_normal = function(a,b) {
+      return a.name < b.name ? -1 : 1;
+   };
+
+   var func_reverse = function(a,b) {
+      return a.name > b.name ? -1 : 1;
+   };
+
+   
+   newnodes.sort(sort=="reverse" ? func_reverse : func_normal);
+   
+   return newnodes;
+}
+
 // start with simple request which already exists in the ROOT itself, 
 // should return items for specified folder
 // following parameters are supported:
 //   path - string path of requested node
 //   first - first child to deliver (default 0)
 //   number - number of childs to deliver 
+//   sort - sorting order
 
 app.get('/hierarchy', function (req, res) {
    
@@ -134,17 +156,22 @@ app.get('/hierarchy', function (req, res) {
       
       console.log('Request path=',req.query.path,"first=", req.query.first || 0, "number=", req.query.number);
       
-      reply.nchilds = node.nodes.length; 
+      var nodes = node.nodes;
+      
+      if (req.query.sort)
+         nodes = doSorting(nodes, req.query.sort);
+      
+      reply.nchilds = nodes.length; 
 
       let first = 0; // only 100 items are send by default
       if (req.query.first) first = Math.max(0, parseInt(req.query.first));
       let number = 100;
       if (req.query.number) number = parseInt(req.query.number);
-      let last = Math.min(node.nodes.length, first + number);
+      let last = Math.min(nodes.length, first + number);
       
       reply.first = first;
-      for (var k=first; k<last; ++k) {
-         let sub = node.nodes[k];
+      for (var k = first; k<last; ++k) {
+         let sub = nodes[k];
          let chld = { _name: sub.name, type: sub.type };
          if (sub.nodes) chld._nchilds = sub.nodes.length; // provide also number of childs
          if (sub._expanded) chld._expanded = true; // deliver initial expand state to client

--- a/lib/server.js
+++ b/lib/server.js
@@ -11,8 +11,6 @@ const compression = require('compression');
 
 const app = express();
 
-let nodeByPath = {};
-
 let root = {
 	"name": "ROOT",
 	"type": "folder",
@@ -21,7 +19,6 @@ let root = {
 	"expanded": true,
 	"level": 0
 };
-nodeByPath[root.path] = root;
 
 function buildNodes(node) {
 	if (node.type === "folder" && node.level < 3) {
@@ -33,7 +30,6 @@ function buildNodes(node) {
 				"path": node.path + "Folder" + i + "/",
 				"level": node.level + 1
 			};
-			nodeByPath[child.path] = child;
 			buildNodes(child);
 			child.expanded = child.nodes.length > 0;
 			node.nodes.push(child);
@@ -45,12 +41,40 @@ function buildNodes(node) {
 				"path": node.path + "File" + i,
 				"level": node.level + 1
 			};
-			nodeByPath[child.path] = child;
 			node.nodes.push(child);
 		}
 	}
 }
+
 buildNodes(root);
+
+// return node by path
+function getNodeByPath(path) {
+   if ((typeof path !== "string") || (path[0] !== "/")) return null;
+   
+   if (!path || (path === "/")) return root;
+   
+   var curr = root;
+   
+   var names = path.split("/");
+   
+   while (names.length > 0) {
+      var name = names.shift(), find = false;
+      if (!name) continue;
+      
+      for (var k=0;k<curr.nodes.length;++k) {
+         if (curr.nodes[k].name == name) {
+            curr = curr.nodes[k];
+            find = true; 
+            break;
+         }
+      }
+      
+      if (!find) return null;
+   }
+   
+   return curr;
+}
 
 function flattenTree(node, nodes) {
 	let flatNodes = nodes || [];
@@ -81,13 +105,37 @@ app.use(compression({
 	}
 }));
 
+
+// start with simple request which already exists in the ROOT itself, 
+// should return items for specified folder
+// now ignore all kinds of ranges logic 
+
+app.get('/hierarchy', function (req, res) {
+   
+   let node = getNodeByPath(req.query.path);
+   
+   var res = [];
+   
+   if (node) 
+      for (var k=0;k<node.nodes.length;++k)
+         res.push({name: node.nodes[k].name, type: node.nodes[k].type });
+   
+   console.log('Sending h reply len=' + res.length);
+   
+   res.write(JSON.stringify(res, 2, "\t"));
+   res.contentType = "text/json";
+   res.end();
+});
+
+
 // handle the data requests to resources
 app.get('/data', function (req, res) {
 	if (req.query.toggle) {
 		// not optimal but simple, should just sketch the idea! => very expensive to toggle like this!!!!
 		let data = flattenTree(root); 
 		let indexToToggle = parseInt(req.query.toggle);
-		let node = nodeByPath[data[indexToToggle].path];
+		console.log('toggle', indexToToggle, 'path', data[indexToToggle].path);
+		let node = getNodeByPath(data[indexToToggle].path);
 		node.expanded = !node.expanded;
 	}
 	let data = flattenTree(root);

--- a/lib/server.js
+++ b/lib/server.js
@@ -27,12 +27,16 @@ function buildNodes(node) {
 	   
 		for (let i = 0; i < nfolders; i++) {
 			let child = {
-				"name": "Folder" + i,
-				"type": "folder",
-				"nodes": [],
-				"path": node.path + "Folder" + i + "/",
-				"level": node.level + 1
+				name: "Folder" + i,
+				type: "folder",
+				nodes: [],
+				path: node.path + "Folder" + i + "/",
+				level: node.level + 1
 			};
+			
+			// mark child as expanded - should automatically expand on client side
+			if (child.name == "Folder5") child._expanded = true;
+			
 			buildNodes(child);
 			child.expanded = child.nodes.length > 0;
 			node.nodes.push(child);
@@ -108,10 +112,8 @@ app.use(compression({
 	}
 }));
 
-
 // start with simple request which already exists in the ROOT itself, 
 // should return items for specified folder
-// now ignore all kinds of ranges logic 
 // following parameters are supported:
 //   path - string path of requested node
 //   first - first child to deliver (default 0)
@@ -144,7 +146,8 @@ app.get('/hierarchy', function (req, res) {
       for (var k=first; k<last; ++k) {
          let sub = node.nodes[k];
          let chld = { _name: sub.name, type: sub.type };
-         if (sub.nodes) chld._nchilds = sub.nodes.length; // provide also number of childs 
+         if (sub.nodes) chld._nchilds = sub.nodes.length; // provide also number of childs
+         if (sub._expanded) chld._expanded = true; // deliver initial expand state to client
          reply.nodes.push(chld);
       }
    }

--- a/lib/server.js
+++ b/lib/server.js
@@ -22,7 +22,10 @@ let root = {
 
 function buildNodes(node) {
 	if (node.type === "folder" && node.level < 3) {
-		for (let i = 0; i < 10; i++) {
+	   var nfolders = node.level == 0 ? 200 : 20,
+	       nfiles = 50;
+	   
+		for (let i = 0; i < nfolders; i++) {
 			let child = {
 				"name": "Folder" + i,
 				"type": "folder",
@@ -34,7 +37,7 @@ function buildNodes(node) {
 			child.expanded = child.nodes.length > 0;
 			node.nodes.push(child);
 		}
-		for (let i = 0; i < 25; i++) {
+		for (let i = 0; i < nfiles; i++) {
 			let child = {
 				"name": "File" + i,
 				"type": "file",
@@ -126,13 +129,16 @@ app.get('/hierarchy', function (req, res) {
    };
    
    if (node && node.nodes) {
+      
+      console.log('Request path=',req.query.path,"first=", req.query.first || 0, "number=", req.query.number);
+      
       reply.nchilds = node.nodes.length; 
 
-      let first = 0, last = 100; // only 100 items are send by default
+      let first = 0; // only 100 items are send by default
       if (req.query.first) first = Math.max(0, parseInt(req.query.first));
-      if (req.query.number) last = Math.min(last, first + parseInt(req.query.number));
-      
-      last = Math.min(last, node.nodes.length);
+      let number = 100;
+      if (req.query.number) number = parseInt(req.query.number);
+      let last = Math.min(node.nodes.length, first + number);
       
       reply.first = first;
       for (var k=first; k<last; ++k) {

--- a/lib/server.js
+++ b/lib/server.js
@@ -97,6 +97,7 @@ app.get('/data', function (req, res) {
 		"nodes": data.slice(start, end),
 		"length": data.length
 	}
+	console.log('Sending reply start=' + start + " end=" + end)
 	res.write(JSON.stringify(responseData, 2, "\t"));
 	res.contentType = "text/json";
 	res.end();

--- a/lib/server.js
+++ b/lib/server.js
@@ -109,20 +109,43 @@ app.use(compression({
 // start with simple request which already exists in the ROOT itself, 
 // should return items for specified folder
 // now ignore all kinds of ranges logic 
+// following parameters are supported:
+//   path - string path of requested node
+//   first - first child to deliver (default 0)
+//   number - number of childs to deliver 
 
 app.get('/hierarchy', function (req, res) {
    
    let node = getNodeByPath(req.query.path);
    
-   let nodes = [];
+   let reply = {
+       path: req.query.path,
+       nchilds: 0, // total number of childs in the path 
+       first: 0,  // first child in the result 
+       nodes: []  // requested childs
+   };
    
-   if (node) 
-      for (var k=0;k<node.nodes.length;++k)
-         nodes.push({ _name: node.nodes[k].name, type: node.nodes[k].type });
+   if (node && node.nodes) {
+      reply.nchilds = node.nodes.length; 
+
+      let first = 0, last = 100; // only 100 items are send by default
+      if (req.query.first) first = Math.max(0, parseInt(req.query.first));
+      if (req.query.number) last = Math.min(last, first + parseInt(req.query.number));
+      
+      last = Math.min(last, node.nodes.length);
+      
+      reply.first = first;
+      for (var k=first; k<last; ++k) {
+         let sub = node.nodes[k];
+         let chld = { _name: sub.name, type: sub.type };
+         if (sub.nodes) chld._nchilds = sub.nodes.length; // provide also number of childs 
+         reply.nodes.push(chld);
+      }
+   }
    
-   console.log('Sending h reply len=' + nodes.length);
+   console.log('Sending h reply len=' + reply.nodes.length);
    
-   res.write(JSON.stringify(nodes, 2, "\t"));
+   res.write(JSON.stringify(reply));
    res.contentType = "text/json";
    res.end();
 });

--- a/webapp/Component.js
+++ b/webapp/Component.js
@@ -38,7 +38,7 @@ sap.ui.define([
 			// this.setModel(new RootModel("/data"));
 
 			// this is new model, flat list produced on client side
-			this.setModel(new hRootModel("/hierarchy"), "browse");
+			// this.setModel(new hRootModel("/hierarchy"), "browse");
 
 
 		}

--- a/webapp/Component.js
+++ b/webapp/Component.js
@@ -15,9 +15,9 @@ sap.ui.define([
 			manifest: "json"
 		},
 
-		
+
 		// QUESTION: can we do it without Component.js, assign model directly for TreeTable control?
-		
+
 		/**
 		 * The component is initialized by UI5 automatically during the startup of the app and calls the init method once.
 		 * @public
@@ -35,9 +35,9 @@ sap.ui.define([
 
 			// old RootModel with flat list on server side
 			// this.setModel(new RootModel("/data"));
-			
+
 			// this is new model, flat list produced on client side
-			this.setModel(new hRootModel("/hierarchy"));
+			this.setModel(new hRootModel("/hierarchy"), "browse");
 
 		}
 	});

--- a/webapp/Component.js
+++ b/webapp/Component.js
@@ -34,7 +34,7 @@ sap.ui.define([
 			// this.setModel(new RootModel("/data"));
 			
 			// this is new model, flat list produced on client side
-			this.setModel(new hRootModel("/data"));
+			this.setModel(new hRootModel("/hierarchy"));
 
 		}
 	});

--- a/webapp/Component.js
+++ b/webapp/Component.js
@@ -12,7 +12,8 @@ sap.ui.define([
 	return UIComponent.extend("root.Component", {
 
 		metadata: {
-			manifest: "json"
+			manifest: "json",
+			id: "myId"
 		},
 
 
@@ -38,6 +39,7 @@ sap.ui.define([
 
 			// this is new model, flat list produced on client side
 			this.setModel(new hRootModel("/hierarchy"), "browse");
+
 
 		}
 	});

--- a/webapp/Component.js
+++ b/webapp/Component.js
@@ -15,6 +15,9 @@ sap.ui.define([
 			manifest: "json"
 		},
 
+		
+		// QUESTION: can we do it without Component.js, assign model directly for TreeTable control?
+		
 		/**
 		 * The component is initialized by UI5 automatically during the startup of the app and calls the init method once.
 		 * @public

--- a/webapp/Component.js
+++ b/webapp/Component.js
@@ -3,9 +3,10 @@ sap.ui.define([
 	"sap/ui/Device",
 	"root/model/models",
 	"root/model/Model",
+   "root/model/hModel",
 	"sap/m/routing/Router", // needed for packaging
 	"sap/ui/core/ComponentSupport" // needed for packaging
-], function (UIComponent, Device, models, RootModel) {
+], function (UIComponent, Device, models, RootModel, hRootModel) {
 	"use strict";
 
 	return UIComponent.extend("root.Component", {
@@ -29,8 +30,11 @@ sap.ui.define([
 			// set the device model
 			this.setModel(models.createDeviceModel(), "device");
 
-			// create and set the RootModel
-			this.setModel(new RootModel("/data"));
+			// old RootModel with flat list on server side
+			// this.setModel(new RootModel("/data"));
+			
+			// this is new model, flat list produced on client side
+			this.setModel(new hRootModel("/data"));
 
 		}
 	});

--- a/webapp/controller/Main.controller.js
+++ b/webapp/controller/Main.controller.js
@@ -4,25 +4,25 @@ sap.ui.define([
 	"use strict";
 
 	return Controller.extend("root.controller.Main", {
-	   
+
 	   changeSort: function() {
-         var model = this.getView().getModel(); 
+         var model = this.getView().getModel("browse");
          var kind = model.getProperty("/sortOrder");
          kind = (kind == "reverse") ? "direct" : "reverse";
-         
+
          model.setProperty("/sortOrder", kind);
          if (model.changeSortOrder)
             model.changeSortOrder(kind);
 	   },
-	   
+
 	   sortOrderChanged: function() {
-	      
-	      var model = this.getView().getModel(); 
-	      
+
+	      var model = this.getView().getModel("browse");
+
          var kind = model.getProperty("/sortOrder");
 
 	      console.log('ORDER CHANGED', kind);
-	      
+
 	      if (model.changeSortOrder)
 	         model.changeSortOrder(kind);
 	   }

--- a/webapp/controller/Main.controller.js
+++ b/webapp/controller/Main.controller.js
@@ -5,6 +5,16 @@ sap.ui.define([
 
 	return Controller.extend("root.controller.Main", {
 	   
+	   changeSort: function() {
+         var model = this.getView().getModel(); 
+         var kind = model.getProperty("/sortOrder");
+         kind = (kind == "reverse") ? "direct" : "reverse";
+         
+         model.setProperty("/sortOrder", kind);
+         if (model.changeSortOrder)
+            model.changeSortOrder(kind);
+	   },
+	   
 	   sortOrderChanged: function() {
 	      
 	      var model = this.getView().getModel(); 

--- a/webapp/controller/Main.controller.js
+++ b/webapp/controller/Main.controller.js
@@ -1,9 +1,21 @@
 sap.ui.define([
-	"sap/ui/core/mvc/Controller"
-], function (Controller) {
+	"sap/ui/core/mvc/Controller",
+	"root/model/hModel"
+], function (Controller, hRootModel) {
 	"use strict";
 
 	return Controller.extend("root.controller.Main", {
+
+
+	   onInit: function() {
+	      console.log('!!!Creating Main controller!!!!');
+
+	      // Not exists
+	      //this.setModel(new hRootModel("/hierarchy"), "browse");
+
+	      // bindTree method of model not invoked
+	      // sap.ui.getCore().setModel(new hRootModel("/hierarchy"), "browse");
+	   },
 
 	   changeSort: function() {
          var model = this.getView().getModel("browse");

--- a/webapp/controller/Main.controller.js
+++ b/webapp/controller/Main.controller.js
@@ -10,11 +10,8 @@ sap.ui.define([
 	   onInit: function() {
 	      console.log('!!!Creating Main controller!!!!');
 
-	      // Not exists
-	      //this.setModel(new hRootModel("/hierarchy"), "browse");
-
-	      // bindTree method of model not invoked
-	      // sap.ui.getCore().setModel(new hRootModel("/hierarchy"), "browse");
+	      // assign model in the controller - more flexible solution for the complex applications
+	      this.getView().setModel(new hRootModel("/hierarchy"), "browse");
 	   },
 
 	   changeSort: function() {

--- a/webapp/controller/Main.controller.js
+++ b/webapp/controller/Main.controller.js
@@ -4,6 +4,18 @@ sap.ui.define([
 	"use strict";
 
 	return Controller.extend("root.controller.Main", {
+	   
+	   sortOrderChanged: function() {
+	      
+	      var model = this.getView().getModel(); 
+	      
+         var kind = model.getProperty("/sortOrder");
+
+	      console.log('ORDER CHANGED', kind);
+	      
+	      if (model.changeSortOrder)
+	         model.changeSortOrder(kind);
+	   }
 
 	});
 });

--- a/webapp/model/ListBinding.js
+++ b/webapp/model/ListBinding.js
@@ -23,8 +23,6 @@ sap.ui.define([
                 for (var i = iStartIndex, l = iStartIndex + iLength; i < l; i++) {
                     var oNode = data[i];
                     if (oNode) {
-                       console.log(this.getPath() + "/" + i," context ", this.getModel().getContext(this.getPath() + "/" + i));
-                       
                         aNodes.push({
                             context: this.getModel().getContext(this.getPath() + "/" + i),
                             type: oNode.type,

--- a/webapp/model/ListBinding.js
+++ b/webapp/model/ListBinding.js
@@ -23,6 +23,8 @@ sap.ui.define([
                 for (var i = iStartIndex, l = iStartIndex + iLength; i < l; i++) {
                     var oNode = data[i];
                     if (oNode) {
+                       console.log(this.getPath() + "/" + i," context ", this.getModel().getContext(this.getPath() + "/" + i));
+                       
                         aNodes.push({
                             context: this.getModel().getContext(this.getPath() + "/" + i),
                             type: oNode.type,

--- a/webapp/model/Model.js
+++ b/webapp/model/Model.js
@@ -38,14 +38,15 @@ sap.ui.define([
                     var data = this.getProperty("/");
                     data.length = responseData.length || 0;
                     responseData.nodes.forEach(function(node, index, arr) {
+                       console.log('assign node', node.index, node.name)
                         data.nodes[node.index] = node
                     });
                     this.setProperty("/", data);
                     
                     // notify the listeners that the nodes has been loaded properly
-                    this.fireRequestCompleted({
-                        type: sType, url : sUrl, method : sMethod, success: true
-                    });
+                    //this.fireRequestCompleted({
+                    //    type: sType, url : sUrl, method : sMethod, success: true
+                    //});
                     
                     // resolve the Promise
                     resolve(data);
@@ -73,9 +74,9 @@ sap.ui.define([
                 }.bind(this));
                 
                 // notify the listeners that a request has been sent 
-                this.fireRequestSent({
-                    type: sType, url : sUrl, method : sMethod
-                });
+                //this.fireRequestSent({
+                //    type: sType, url : sUrl, method : sMethod
+                //});
 
             }.bind(this));
 

--- a/webapp/model/Model.js
+++ b/webapp/model/Model.js
@@ -38,7 +38,6 @@ sap.ui.define([
                     var data = this.getProperty("/");
                     data.length = responseData.length || 0;
                     responseData.nodes.forEach(function(node, index, arr) {
-                       console.log('assign node', node.index, node.name)
                         data.nodes[node.index] = node
                     });
                     this.setProperty("/", data);

--- a/webapp/model/hListBinding.js
+++ b/webapp/model/hListBinding.js
@@ -1,0 +1,100 @@
+sap.ui.define([
+    "sap/base/Log", 
+    "sap/ui/model/json/JSONListBinding"
+], function(Log, JSONListBinding) {
+    "use strict";
+
+    var bLoading = false;
+
+    var RootListBinding = JSONListBinding.extend("root.model.ListBinding", {
+
+        // called by the TreeTable to know the amount of entries
+        getLength: function() {
+            Log.warning("root.model.ListBinding#getLength()");
+            return this.getModel().getProperty("/length") || 0;
+        },
+
+        // function is called by the TreeTable when requesting the data to display
+        getNodes: function(iStartIndex, iLength, iThreshold) {
+            Log.warning("root.model.ListBinding#getNodes(" + iStartIndex + ", " + iLength + ", " + iThreshold + ")");
+            var data = this.getModel().getProperty(this.getPath());
+            var aNodes = [];
+            if (!bLoading) {
+                for (var i = iStartIndex, l = iStartIndex + iLength; i < l; i++) {
+                    var oNode = data[i];
+                    if (oNode) {
+                        aNodes.push({
+                            context: this.getModel().getContext(this.getPath() + "/" + i),
+                            type: oNode.type,
+                            isLeaf:  oNode.type === "file",
+                            level: oNode.level,
+                            nodeState: {
+                                expanded: oNode.expanded,
+                                selected: oNode.selected,
+                                sum: false
+                            } 
+                        });
+                    }
+                }
+                if (aNodes.length != Math.min(iLength, this.getModel().getProperty("/length"))) {
+                    bLoading = true;
+                    this.getModel().loadEntries(iStartIndex, iLength, iThreshold).then(function() {
+                        bLoading = false;
+                        this.checkUpdate(true); // force update
+                    }.bind(this), function() {
+                        bLoading = false;
+                        this.checkUpdate(true); // force update
+                    }.bind(this));
+                    return [];
+                }
+            }
+            return aNodes;
+        },
+
+        getContextByIndex: function(iIndex) {
+            Log.warning("root.model.ListBinding#getContextByIndex(" + iIndex + ")");
+        },
+
+        findNode: function() {
+            Log.warning("root.model.ListBinding#findNode()");
+        },
+    
+        nodeHasChildren: function(oNode) {
+            Log.warning("root.model.ListBinding#nodeHasChildren(" + oNode.context.getPath() + ")");
+            return oNode.type === "folder";
+        },
+    
+        isExpanded: function(iIndex) {
+            Log.warning("root.model.ListBinding#isExpanded(" + iIndex + ")");
+            return this.getNodes(iIndex, 1)[0].nodeState.expanded;
+        },
+
+        expand: function(iIndex) {
+            Log.warning("root.model.ListBinding#expand(" + iIndex + ")");
+        },
+    
+        collapse: function(iIndex) {
+            Log.warning("root.model.ListBinding#collapse(" + iIndex + ")");
+        },
+    
+        // called by the TreeTable when a node is expanded/collapsed
+        toggleIndex: function(iIndex) {
+            Log.warning("root.model.ListBinding#toggleIndex(" + iIndex + ")");
+            var oContext = this.getModel().getContext(this.getPath() + "/" + iIndex);
+            oContext.getProperty().expanded = !oContext.getProperty().expanded;
+            this.getModel().toggleNode(oContext.getProperty("index"));
+        },
+    
+        getSelectedIndex: function() {
+            Log.warning("root.model.ListBinding#getSelectedIndex(" + JSON.stringify(arguments) + ")");
+        },
+    
+        isIndexSelectable: function() {
+            Log.warning("root.model.ListBinding#isIndexSelectable(" + JSON.stringify(arguments) + ")");
+        }
+
+    });
+
+    return RootListBinding;
+
+});

--- a/webapp/model/hListBinding.js
+++ b/webapp/model/hListBinding.js
@@ -30,13 +30,15 @@ sap.ui.define([
                  var oNode = data[i];
                  if (oNode) {
                      aNodes.push({
-                         context: this.getModel().getContext(this.getPath() + "/" + i),
                          type: oNode.type,
                          isLeaf: oNode.type === "file",
                          level: oNode.level,
-                         nodeState: {
-                             expanded: oNode.expanded,
-                             selected: oNode.selected,
+                         
+                         // QUESTION: seems to be, this is required by JSONListBinding?
+                         context: this.getModel().getContext(this.getPath() + "/" + i),
+                         nodeState: {  
+                             expanded: !!oNode._elem._expanded, 
+                             selected: !!oNode._elem._selected,
                              sum: false
                          } 
                      });
@@ -62,15 +64,12 @@ sap.ui.define([
         },
     
         isExpanded: function(iIndex) {
-            Log.warning("root.model.hListBinding#isExpanded(" + iIndex + ")");
-            
             var elem = this.getModel().getElementByIndex(iIndex);
-            
             var res = elem ? !!elem._expanded : false;
             
             Log.warning("root.model.hListBinding#isExpanded(" + iIndex + ") res = " + res);
             
-            return elem ? !!elem._expanded : false;
+            return res;
         },
 
         expand: function(iIndex) {

--- a/webapp/model/hListBinding.js
+++ b/webapp/model/hListBinding.js
@@ -1,5 +1,5 @@
 sap.ui.define([
-    "sap/base/Log", 
+    "sap/base/Log",
     "sap/ui/model/json/JSONListBinding"
 ], function(Log, JSONListBinding) {
     "use strict";
@@ -20,15 +20,15 @@ sap.ui.define([
            var args = {
               begin: iStartIndex,
               end: iStartIndex + iLength,
-              threshold: iThreshold 
+              threshold: iThreshold
            };
-           
+
            this.getModel().buildFlatNodes(args);
-           
+
            var aNodes = [];
-           
+
            var nodes = this.getModel().getProperty("/nodes");
-           
+
            for (var i = args.begin; i < args.end; i++) {
               var oNode = nodes[i];
               if (oNode) {
@@ -39,11 +39,11 @@ sap.ui.define([
 
                     // QUESTION: seems to be, this is required by JSONListBinding?
                     context: this.getModel().getContext(this.getPath() + "/" + i),
-                    nodeState: {  
-                       expanded: !!oNode._elem._expanded, 
+                    nodeState: {
+                       expanded: !!oNode._elem._expanded,
                        selected: !!oNode._elem._selected,
-                       sum: false
-                    } 
+                       sum: false // ????
+                    }
                  });
               } else {
                  aNodes.push(null); // dummy entry
@@ -51,7 +51,7 @@ sap.ui.define([
            }
 
            Log.warning("root.model.hListBinding#getNodes(" + iStartIndex + ", " + iLength + ", " + iThreshold + ") res = " + aNodes.length);
-           
+
            return aNodes;
         },
 
@@ -63,42 +63,42 @@ sap.ui.define([
         findNode: function() {
             Log.warning("root.model.hListBinding#findNode()");
         },
-    
+
         nodeHasChildren: function(oNode) {
            // Log.warning("root.model.hListBinding#nodeHasChildren(" + oNode.type + ")");
             return oNode.type === "folder";
         },
-    
+
         isExpanded: function(iIndex) {
             var elem = this.getModel().getElementByIndex(iIndex);
             var res = elem ? !!elem._expanded : false;
-            
+
             Log.warning("root.model.hListBinding#isExpanded(" + iIndex + ") res = " + res + "  iselem = " + (elem ? elem._name : "---"));
-            
+
             return res;
         },
 
         expand: function(iIndex) {
             Log.warning("root.model.hListBinding#expand(" + iIndex + ")");
         },
-    
+
         collapse: function(iIndex) {
             Log.warning("root.model.hListBinding#collapse(" + iIndex + ")");
         },
-    
+
         // called by the TreeTable when a node is expanded/collapsed
         toggleIndex: function(iIndex) {
             Log.warning("root.model.hListBinding#toggleIndex(" + iIndex + ")");
             if (this.getModel().toggleNode(iIndex))
                this.checkUpdate(true);
-            
-            // QUESTION: why one should call checkUpdate?, should it be done automatically always? 
+
+            // QUESTION: why one should call checkUpdate?, should it be done automatically always?
         },
-    
+
         getSelectedIndex: function() {
             Log.warning("root.model.hListBinding#getSelectedIndex(" + JSON.stringify(arguments) + ")");
         },
-    
+
         isIndexSelectable: function() {
             Log.warning("root.model.hListBinding#isIndexSelectable(" + JSON.stringify(arguments) + ")");
         }

--- a/webapp/model/hListBinding.js
+++ b/webapp/model/hListBinding.js
@@ -17,38 +17,51 @@ sap.ui.define([
         // function is called by the TreeTable when requesting the data to display
         getNodes: function(iStartIndex, iLength, iThreshold) {
 
-           Log.warning("root.model.hListBinding#getNodes(" + iStartIndex + ", " + iLength + ", " + iThreshold + ")");
-
            var args = {
               begin: iStartIndex,
               end: iStartIndex + iLength,
               threshold: iThreshold 
            };
            
-           var totalLen = this.getModel().buildFlatNodes(args);
+           this.getModel().buildFlatNodes(args);
            
            var aNodes = [];
            
-           if (totalLen > 0) {
-              for (var i = args.begin; i < args.end; i++) {
-                 var oNode = args.nodes[i];
-                 if (oNode) {
-                     aNodes.push({
-                         type: oNode.type,
-                         isLeaf: oNode.type === "file",
-                         level: oNode.level,
-                         
-                         // QUESTION: seems to be, this is required by JSONListBinding?
-                         context: this.getModel().getContext(this.getPath() + "/" + i),
-                         nodeState: {  
-                             expanded: !!oNode._elem._expanded, 
-                             selected: !!oNode._elem._selected,
-                             sum: false
-                         } 
-                     });
-                 }
+           for (var i = args.begin; i < args.end; i++) {
+              var oNode = args.nodes[i];
+              if (oNode) {
+                 aNodes.push({
+                    type: oNode.type,
+                    isLeaf: oNode.type === "file",
+                    level: oNode.level,
+
+                    // QUESTION: seems to be, this is required by JSONListBinding?
+                    context: this.getModel().getContext(this.getPath() + "/" + i),
+                    nodeState: {  
+                       expanded: !!oNode._elem._expanded, 
+                       selected: !!oNode._elem._selected,
+                       sum: false
+                    } 
+                 });
+              } else {
+                 aNodes.push({
+                    type: "file",
+                    isLeaf: true,
+                    level: 1,
+
+                    // QUESTION: seems to be, this is required by JSONListBinding?
+                    context: this.getModel().getContext(this.getPath() + "/" + i),
+                    nodeState: {  
+                       expanded: false, 
+                       selected: false,
+                       sum: false
+                    } 
+                 });
+
               }
            }
+
+           Log.warning("root.model.hListBinding#getNodes(" + iStartIndex + ", " + iLength + ", " + iThreshold + ") res = " + aNodes.length);
            
            return aNodes;
            
@@ -56,6 +69,7 @@ sap.ui.define([
 
         getContextByIndex: function(iIndex) {
             Log.warning("root.model.hListBinding#getContextByIndex(" + iIndex + ")");
+            return this.getModel().getContext(this.getPath() + "/" + iIndex);
         },
 
         findNode: function() {

--- a/webapp/model/hListBinding.js
+++ b/webapp/model/hListBinding.js
@@ -27,8 +27,10 @@ sap.ui.define([
            
            var aNodes = [];
            
+           var nodes = this.getModel().getProperty("/nodes");
+           
            for (var i = args.begin; i < args.end; i++) {
-              var oNode = args.nodes[i];
+              var oNode = nodes[i];
               if (oNode) {
                  aNodes.push({
                     type: oNode.type,
@@ -87,7 +89,10 @@ sap.ui.define([
         // called by the TreeTable when a node is expanded/collapsed
         toggleIndex: function(iIndex) {
             Log.warning("root.model.hListBinding#toggleIndex(" + iIndex + ")");
-            this.getModel().toggleNode(iIndex);
+            if (this.getModel().toggleNode(iIndex))
+               this.checkUpdate(true);
+            
+            // QUESTION: why one should call checkUpdate?, should it be done automatically always? 
         },
     
         getSelectedIndex: function() {

--- a/webapp/model/hListBinding.js
+++ b/webapp/model/hListBinding.js
@@ -32,7 +32,7 @@ sap.ui.define([
                      aNodes.push({
                          context: this.getModel().getContext(this.getPath() + "/" + i),
                          type: oNode.type,
-                         isLeaf:  oNode.type === "file",
+                         isLeaf: oNode.type === "file",
                          level: oNode.level,
                          nodeState: {
                              expanded: oNode.expanded,
@@ -57,13 +57,20 @@ sap.ui.define([
         },
     
         nodeHasChildren: function(oNode) {
-            Log.warning("root.model.hListBinding#nodeHasChildren(" + oNode.context.getPath() + ")");
+            Log.warning("root.model.hListBinding#nodeHasChildren(" + oNode.type + ")");
             return oNode.type === "folder";
         },
     
         isExpanded: function(iIndex) {
             Log.warning("root.model.hListBinding#isExpanded(" + iIndex + ")");
-            return this.getNodes(iIndex, 1)[0].nodeState.expanded;
+            
+            var elem = this.getModel().getElementByIndex(iIndex);
+            
+            var res = elem ? !!elem._expanded : false;
+            
+            Log.warning("root.model.hListBinding#isExpanded(" + iIndex + ") res = " + res);
+            
+            return elem ? !!elem._expanded : false;
         },
 
         expand: function(iIndex) {
@@ -77,9 +84,7 @@ sap.ui.define([
         // called by the TreeTable when a node is expanded/collapsed
         toggleIndex: function(iIndex) {
             Log.warning("root.model.hListBinding#toggleIndex(" + iIndex + ")");
-            var oContext = this.getModel().getContext(this.getPath() + "/" + iIndex);
-            oContext.getProperty().expanded = !oContext.getProperty().expanded;
-            this.getModel().toggleNode(oContext.getProperty("index"));
+            this.getModel().toggleNode(iIndex);
         },
     
         getSelectedIndex: function() {

--- a/webapp/model/hListBinding.js
+++ b/webapp/model/hListBinding.js
@@ -16,42 +16,15 @@ sap.ui.define([
 
         // function is called by the TreeTable when requesting the data to display
         getNodes: function(iStartIndex, iLength, iThreshold) {
-            Log.warning("root.model.hListBinding#getNodes(" + iStartIndex + ", " + iLength + ", " + iThreshold + ")");
-            var data = this.getModel().getProperty(this.getPath());
-            var aNodes = [];
-            if (!bLoading) {
-                for (var i = iStartIndex, l = iStartIndex + iLength; i < l; i++) {
-                    var oNode = data[i];
-                    if (oNode) {
-                        aNodes.push({
-                            context: this.getModel().getContext(this.getPath() + "/" + i),
-                            type: oNode.type,
-                            isLeaf:  oNode.type === "file",
-                            level: oNode.level,
-                            nodeState: {
-                                expanded: oNode.expanded,
-                                selected: oNode.selected,
-                                sum: false
-                            } 
-                        });
-                    }
-                }
-                if (aNodes.length != Math.min(iLength, this.getModel().getProperty("/length"))) {
-                    bLoading = true;
-                    this.getModel().loadEntries(iStartIndex, iLength, iThreshold).then(function() {
-                        bLoading = false;
-                        this.checkUpdate(true); // force update
-                    }.bind(this), function() {
-                        bLoading = false;
-                        this.checkUpdate(true); // force update
-                    }.bind(this));
-                    return [];
-                }
-            }
-            
-            if (aNodes.length > 0) console.log('!!!! RETURN ', aNodes.length);
-            
-            return aNodes;
+
+           Log.warning("root.model.hListBinding#getNodes(" + iStartIndex + ", " + iLength + ", " + iThreshold + ")");
+
+           var res = this.getModel().getNodes(iStartIndex, iLength, iThreshold);
+           
+           Log.warning("root.model.hListBinding#getNodes(res.length = " + res.length + ")");
+           
+           return res;
+           
         },
 
         getContextByIndex: function(iIndex) {

--- a/webapp/model/hListBinding.js
+++ b/webapp/model/hListBinding.js
@@ -19,15 +19,18 @@ sap.ui.define([
 
            Log.warning("root.model.hListBinding#getNodes(" + iStartIndex + ", " + iLength + ", " + iThreshold + ")");
 
+           var args = {
+              begin: iStartIndex,
+              end: iStartIndex + iLength,
+              threshold: Math.max(iStartIndex + iThreshold, iStartIndex + iLength) 
+           };
+           
            var aNodes = [];
            
-           var totalLen = this.getModel().buildFlatNodes(true);
+           var totalLen = this.getModel().buildFlatNodes(args);
            if (totalLen > 0) {
-              var beg = iStartIndex || 0;
-              var end = Math.min(beg + (iLength || 100), totalLen);
-              var data = this.getModel().getProperty(this.getPath());
-              for (var i = beg; i < end; i++) {
-                 var oNode = data[i];
+              for (var i = args.begin; i < args.end; i++) {
+                 var oNode = args.nodes[i];
                  if (oNode) {
                      aNodes.push({
                          type: oNode.type,

--- a/webapp/model/hListBinding.js
+++ b/webapp/model/hListBinding.js
@@ -10,7 +10,7 @@ sap.ui.define([
 
         // called by the TreeTable to know the amount of entries
         getLength: function() {
-            Log.warning("root.model.hListBinding#getLength()");
+            // Log.warning("root.model.hListBinding#getLength()");
             return this.getModel().getLength();
         },
 
@@ -22,12 +22,13 @@ sap.ui.define([
            var args = {
               begin: iStartIndex,
               end: iStartIndex + iLength,
-              threshold: Math.max(iStartIndex + iThreshold, iStartIndex + iLength) 
+              threshold: iThreshold 
            };
+           
+           var totalLen = this.getModel().buildFlatNodes(args);
            
            var aNodes = [];
            
-           var totalLen = this.getModel().buildFlatNodes(args);
            if (totalLen > 0) {
               for (var i = args.begin; i < args.end; i++) {
                  var oNode = args.nodes[i];
@@ -62,7 +63,7 @@ sap.ui.define([
         },
     
         nodeHasChildren: function(oNode) {
-            Log.warning("root.model.hListBinding#nodeHasChildren(" + oNode.type + ")");
+           // Log.warning("root.model.hListBinding#nodeHasChildren(" + oNode.type + ")");
             return oNode.type === "folder";
         },
     

--- a/webapp/model/hListBinding.js
+++ b/webapp/model/hListBinding.js
@@ -6,17 +6,17 @@ sap.ui.define([
 
     var bLoading = false;
 
-    var RootListBinding = JSONListBinding.extend("root.model.ListBinding", {
+    var hRootListBinding = JSONListBinding.extend("root.model.hListBinding", {
 
         // called by the TreeTable to know the amount of entries
         getLength: function() {
-            Log.warning("root.model.ListBinding#getLength()");
-            return this.getModel().getProperty("/length") || 0;
+            Log.warning("root.model.hListBinding#getLength()");
+            return this.getModel().getLength();
         },
 
         // function is called by the TreeTable when requesting the data to display
         getNodes: function(iStartIndex, iLength, iThreshold) {
-            Log.warning("root.model.ListBinding#getNodes(" + iStartIndex + ", " + iLength + ", " + iThreshold + ")");
+            Log.warning("root.model.hListBinding#getNodes(" + iStartIndex + ", " + iLength + ", " + iThreshold + ")");
             var data = this.getModel().getProperty(this.getPath());
             var aNodes = [];
             if (!bLoading) {
@@ -48,53 +48,56 @@ sap.ui.define([
                     return [];
                 }
             }
+            
+            if (aNodes.length > 0) console.log('!!!! RETURN ', aNodes.length);
+            
             return aNodes;
         },
 
         getContextByIndex: function(iIndex) {
-            Log.warning("root.model.ListBinding#getContextByIndex(" + iIndex + ")");
+            Log.warning("root.model.hListBinding#getContextByIndex(" + iIndex + ")");
         },
 
         findNode: function() {
-            Log.warning("root.model.ListBinding#findNode()");
+            Log.warning("root.model.hListBinding#findNode()");
         },
     
         nodeHasChildren: function(oNode) {
-            Log.warning("root.model.ListBinding#nodeHasChildren(" + oNode.context.getPath() + ")");
+            Log.warning("root.model.hListBinding#nodeHasChildren(" + oNode.context.getPath() + ")");
             return oNode.type === "folder";
         },
     
         isExpanded: function(iIndex) {
-            Log.warning("root.model.ListBinding#isExpanded(" + iIndex + ")");
+            Log.warning("root.model.hListBinding#isExpanded(" + iIndex + ")");
             return this.getNodes(iIndex, 1)[0].nodeState.expanded;
         },
 
         expand: function(iIndex) {
-            Log.warning("root.model.ListBinding#expand(" + iIndex + ")");
+            Log.warning("root.model.hListBinding#expand(" + iIndex + ")");
         },
     
         collapse: function(iIndex) {
-            Log.warning("root.model.ListBinding#collapse(" + iIndex + ")");
+            Log.warning("root.model.hListBinding#collapse(" + iIndex + ")");
         },
     
         // called by the TreeTable when a node is expanded/collapsed
         toggleIndex: function(iIndex) {
-            Log.warning("root.model.ListBinding#toggleIndex(" + iIndex + ")");
+            Log.warning("root.model.hListBinding#toggleIndex(" + iIndex + ")");
             var oContext = this.getModel().getContext(this.getPath() + "/" + iIndex);
             oContext.getProperty().expanded = !oContext.getProperty().expanded;
             this.getModel().toggleNode(oContext.getProperty("index"));
         },
     
         getSelectedIndex: function() {
-            Log.warning("root.model.ListBinding#getSelectedIndex(" + JSON.stringify(arguments) + ")");
+            Log.warning("root.model.hListBinding#getSelectedIndex(" + JSON.stringify(arguments) + ")");
         },
     
         isIndexSelectable: function() {
-            Log.warning("root.model.ListBinding#isIndexSelectable(" + JSON.stringify(arguments) + ")");
+            Log.warning("root.model.hListBinding#isIndexSelectable(" + JSON.stringify(arguments) + ")");
         }
 
     });
 
-    return RootListBinding;
+    return hRootListBinding;
 
 });

--- a/webapp/model/hListBinding.js
+++ b/webapp/model/hListBinding.js
@@ -44,27 +44,13 @@ sap.ui.define([
                     } 
                  });
               } else {
-                 aNodes.push({
-                    type: "file",
-                    isLeaf: true,
-                    level: 1,
-
-                    // QUESTION: seems to be, this is required by JSONListBinding?
-                    context: this.getModel().getContext(this.getPath() + "/" + i),
-                    nodeState: {  
-                       expanded: false, 
-                       selected: false,
-                       sum: false
-                    } 
-                 });
-
+                 aNodes.push(null); // dummy entry
               }
            }
 
            Log.warning("root.model.hListBinding#getNodes(" + iStartIndex + ", " + iLength + ", " + iThreshold + ") res = " + aNodes.length);
            
            return aNodes;
-           
         },
 
         getContextByIndex: function(iIndex) {
@@ -85,7 +71,7 @@ sap.ui.define([
             var elem = this.getModel().getElementByIndex(iIndex);
             var res = elem ? !!elem._expanded : false;
             
-            Log.warning("root.model.hListBinding#isExpanded(" + iIndex + ") res = " + res);
+            Log.warning("root.model.hListBinding#isExpanded(" + iIndex + ") res = " + res + "  iselem = " + (elem ? elem._name : "---"));
             
             return res;
         },

--- a/webapp/model/hListBinding.js
+++ b/webapp/model/hListBinding.js
@@ -19,11 +19,32 @@ sap.ui.define([
 
            Log.warning("root.model.hListBinding#getNodes(" + iStartIndex + ", " + iLength + ", " + iThreshold + ")");
 
-           var res = this.getModel().getNodes(iStartIndex, iLength, iThreshold);
+           var aNodes = [];
            
-           Log.warning("root.model.hListBinding#getNodes(res.length = " + res.length + ")");
+           var totalLen = this.getModel().buildFlatNodes(true);
+           if (totalLen > 0) {
+              var beg = iStartIndex || 0;
+              var end = Math.min(beg + (iLength || 100), totalLen);
+              var data = this.getModel().getProperty(this.getPath());
+              for (var i = beg; i < end; i++) {
+                 var oNode = data[i];
+                 if (oNode) {
+                     aNodes.push({
+                         context: this.getModel().getContext(this.getPath() + "/" + i),
+                         type: oNode.type,
+                         isLeaf:  oNode.type === "file",
+                         level: oNode.level,
+                         nodeState: {
+                             expanded: oNode.expanded,
+                             selected: oNode.selected,
+                             sum: false
+                         } 
+                     });
+                 }
+              }
+           }
            
-           return res;
+           return aNodes;
            
         },
 

--- a/webapp/model/hModel.js
+++ b/webapp/model/hModel.js
@@ -13,6 +13,18 @@ sap.ui.define([
             this.setProperty("/", {
                 nodes: {}
             });
+            
+            // this is hierarchy, created on the client side and used for creation of flat list 
+            this.h = {
+               _name: "ROOT",
+               _childs: [],
+               _expanded: true
+            };
+        },
+        
+        getLength: function() {
+            var res = this.getProperty("/length"); 
+            return res || 0;
         },
 
         bindTree: function(sPath, oContext, aFilters, mParameters, aSorters) {

--- a/webapp/model/hModel.js
+++ b/webapp/model/hModel.js
@@ -93,8 +93,7 @@ sap.ui.define([
            function scan(lvl, elem, path) {
               path = !path ? "/" : path + "/" + elem._name;
 
-              if (build_nodes) {
-                 console.log('produce entry',id, lvl, elem._name);
+              if (build_nodes) 
                  data.nodes[id] = {
                     name: elem._name,
                     level: lvl,
@@ -103,7 +102,6 @@ sap.ui.define([
                     isLeaf: elem.type === "file",
                     expanded: !!elem._expanded
                  }
-              }
               
               id++;
               
@@ -157,40 +155,6 @@ sap.ui.define([
 
            // do not return valid number of elements
            return 0;
-        },
-        
-        getNodes: function(iStartIndex, iLength, iThreshold) {
-           // loading not completed
-           var beg = iStartIndex || 0;
-           var end = beg + (iLength || 100); 
-
-           var nodes = [];
-           
-           if (this.buildFlatNodes(true) > 0) {
-              var data = this.getProperty("/nodes");
-              
-              for (var i = beg; i < end; i++) {
-                 var oNode = data[i];
-                 if (oNode) {
-                    console.log("/nodes/" + i," context ", this.getContext("/nodes/" + i));
-                    
-                     nodes.push({
-                         context: this.getContext("/nodes/" + i),
-                         type: oNode.type,
-                         isLeaf:  oNode.type === "file",
-                         level: oNode.level,
-                         nodeState: {
-                             expanded: oNode.expanded,
-                             selected: oNode.selected,
-                             sum: false
-                         } 
-                     });
-                 }
-             }
-
-           }
-           
-           return nodes;
         },
 
         loadEntries: function(start, end, threshold) {

--- a/webapp/model/hModel.js
+++ b/webapp/model/hModel.js
@@ -13,25 +13,25 @@ sap.ui.define([
             this._sBaseUrl = sBaseUrl;
             this.setProperty("/", {
                 nodes: {}, // nodes shown in the TreeTable, should be flat list
-                length: 0  // total number of elements 
+                length: 0  // total number of elements
             });
-            
-            // this is true hierarchy, created on the client side and used for creation of flat list 
+
+            // this is true hierarchy, created on the client side and used for creation of flat list
             this.h = {
                _name: "ROOT",
                _expanded: true
             };
-            
+
             this.loadDataCounter = 0; // counter of number of nodes
-            
+
             this.sortOrder = "";
-            
+
             this.threshold = 100; // default threshold to prefetch items
-            
+
             // submit top-level request already when construct model
             this.submitRequest(this.h, "/");
         },
-        
+
         bindTree: function(sPath, oContext, aFilters, mParameters, aSorters) {
            Log.warning("root.model.hModel#bindTree()");
            this.oBinding = new hListBinding(this, sPath, oContext, aFilters, mParameters, aSorters);
@@ -41,47 +41,47 @@ sap.ui.define([
         getLength: function() {
            return this.getProperty("/length");
         },
-        
+
         getNodeByPath: function(path) {
            var curr = this.h;
            if (!path || (typeof path !== "string") || (path == "/")) return curr;
-           
+
            var names = path.split("/");
-           
+
            while (names.length > 0) {
               var name = names.shift(), find = false;
               if (!name) continue;
-              
+
               for (var k=0;k<curr._childs.length;++k) {
                  if (curr._childs[k]._name == name) {
                     curr = curr._childs[k];
-                    find = true; 
+                    find = true;
                     break;
                  }
               }
-              
+
               if (!find) return null;
            }
            return curr;
         },
 
-        // submit next request to the server 
+        // submit next request to the server
         // now using simple HTTP requests, in ROOT websocket communication will be used
         submitRequest: function(elem, path, first, number) {
-           
+
            if (elem._requested) return;
            elem._requested = true;
-           
+
            this.loadDataCounter++;
-           
+
            var request = "path=" + path;
            if ((first !== undefined) && (number !== undefined))
               request += "&first=" + first + "&number=" + number;
-           
+
            if (this.sortOrder)
               request += "&sort=" + this.sortOrder;
 
-           // TODO: here is just HTTP request, in ROOT we will use websocket to send requests and process replies 
+           // TODO: here is just HTTP request, in ROOT we will use websocket to send requests and process replies
            jQuery.ajax({
               url: this._sBaseUrl + "?" + request,
               dataType: "json",
@@ -89,31 +89,31 @@ sap.ui.define([
           }).done(function(responseData, textStatus, jqXHR) {
 
              this.loadDataCounter--;
-             
+
              this.processResponse(responseData);
-              
+
           }.bind(this)).fail(function(rpath, jqXHR, textStatus, errorThrown) {
-              
+
              this.loadDataCounter--;
-             
+
              // log the error for debugging to see the issue when checking the log
              jQuery.sap.log.error("Failed to read data for " + rpath + "! Reason: " + errorThrown);
-              
+
           }.bind(this, request));
         },
-        
+
         // process reply from server
         // In the future reply will be received via websocket channel
         processResponse: function(reply) {
            var elem = this.getNodeByPath(reply.path);
-           
+
            if (!elem) { console.error('DID NOT FOUND ' + reply.path); return; }
-           
+
            if (!elem._requested) console.error('ELEMENT WAS NOT REQUESTED!!!!', reply.path);
            delete elem._requested;
-           
+
            var smart_merge = false;
-           
+
            if ((elem._nchilds === reply.nchilds) && elem._childs && reply.nodes) {
               if (elem._first + elem._childs.length == reply.first) {
                  elem._childs = elem._childs.concat(reply.nodes);
@@ -130,75 +130,75 @@ sap.ui.define([
               elem._childs = reply.nodes;
               elem._first = reply.first || 0;
            }
-           
+
            this.scanShifts();
 
-           // reset existing nodes if reply does not match with expectation 
+           // reset existing nodes if reply does not match with expectation
            if (!smart_merge)
               this.reset_nodes = true;
 
            if (this.loadDataCounter == 0)
-              if (this.oBinding) 
+              if (this.oBinding)
                  this.oBinding.checkUpdate(true);
         },
-        
-        // return element of hierarchical structure by TreeTable index 
+
+        // return element of hierarchical structure by TreeTable index
         getElementByIndex: function(indx) {
            var nodes = this.getProperty("/nodes"),
                node = nodes ? nodes[indx] : null;
-           
+
            return node ? node._elem : null;
         },
-        
+
         // function used to calculate all ids shifts and total number of elements
         scanShifts: function() {
-           
+
            var id = 0;
-           
+
            function scan(lvl, elem) {
-              
+
               id++;
 
               var before_id = id;
-              
+
               if (elem._expanded) {
                  if (elem._childs === undefined) {
                     // do nothing, childs are not visible as long as we do not have any list
-                    
-                    // id += 0; 
+
+                    // id += 0;
                  } else {
 
                     // gap at the begin
-                    if (elem._first) 
+                    if (elem._first)
                        id += elem._first;
 
                     // jump over all childs
                     for (var k=0;k<elem._childs.length;++k)
                        scan(lvl+1, elem._childs[k]);
-                    
+
                     // gap at the end
                     var _last = (elem._first || 0) + elem._childs.length;
                     var _remains = elem._nchilds  - _last;
                     if (_remains > 0) id += _remains;
                  }
               }
-              
-              // this shift can be later applied to jump over all elements 
-              elem._shift = id - before_id;  
+
+              // this shift can be later applied to jump over all elements
+              elem._shift = id - before_id;
            }
 
            scan(0, this.h);
-           
+
            this.setProperty("/length", id);
-           
+
            return id;
         },
-        
+
         // main  method to create flat list of nodes - only whose which are specified in selection
         // following arguments:
         //    args.begin     - first visisble element from flat list
         //    args.end       - first not-visisble element
-        //    args.threshold - extra elements (before/after) which probably should be prefetched 
+        //    args.threshold - extra elements (before/after) which probably should be prefetched
         // returns total number of nodes
         buildFlatNodes: function(args) {
 
@@ -207,51 +207,51 @@ sap.ui.define([
                threshold = args.threshold || this.threshold || 100,
                threshold2 = Math.round(threshold/2),
                nodes = this.reset_nodes ? {} : this.getProperty("/nodes");
-           
+
            // main method to scan through all existing sub-folders
            function scan(lvl, elem, path) {
               // create elements with safety margin
-              if ((nodes !== null) && !nodes[id] && (id >= args.begin - threshold2) && (id < args.end + threshold2) ) 
+              if ((nodes !== null) && !nodes[id] && (id >= args.begin - threshold2) && (id < args.end + threshold2) )
                  nodes[id] = {
                     name: elem._name,
                     level: lvl,
                     index: id,
                     _elem: elem,
-                    
+
                     // these are optional, should be eliminated in the future
                     type: elem.type,
                     isLeaf: elem.type === "file",
                     expanded: !!elem._expanded
                  };
-              
+
               id++;
 
               if (!elem._expanded) return;
-                 
+
               if (elem._childs === undefined) {
-                 // add new request - can we check if only special part of childs is required? 
+                 // add new request - can we check if only special part of childs is required?
 
                  // TODO: probably one could guess more precise request
                  pthis.submitRequest(elem, path);
-                 
-                 return;  
-              } 
+
+                 return;
+              }
 
               // check if scan is required
               if (((id + elem._shift) < args.begin - threshold2) || (id >= args.end + threshold2)) {
                  id += elem._shift;
                  return;
               }
-                    
+
               // when not all childs from very beginning is loaded, but may be required
               if (elem._first) {
-                       
+
                  // check if requests are needed to load part in the begin of the list
                  if (args.begin - id - threshold2 < elem._first) {
 
                     var first = Math.max(args.begin - id - threshold2, 0),
                         number = Math.min(elem._first - first, threshold);
-                    
+
                     pthis.submitRequest(elem, path, first, number);
                  }
 
@@ -268,24 +268,24 @@ sap.ui.define([
 
               if (_remains > 0) {
                  if (args.end + threshold2 > id) {
-                    
+
                     var first = _last, number = args.end + threshold2 - id;
-                    if (number < threshold) number = threshold; // always request much  
-                    if (number > _remains) number = _remains; // but not too much 
+                    if (number < threshold) number = threshold; // always request much
+                    if (number > _remains) number = _remains; // but not too much
                     if (number > threshold) {
                        first += (number - threshold);
                        number = threshold;
                     }
-                    
+
                     pthis.submitRequest(elem, path, first, number);
                  }
 
                  id += _remains;
-              } 
+              }
            }
-           
+
            scan(0, this.h, "/");
-           
+
            if (this.getProperty("/length") != id) {
               console.error('LENGTH MISMATCH', this.getProperty("/length"), id);
               this.setProperty("/length", id); // update length property
@@ -301,42 +301,42 @@ sap.ui.define([
 
         // toggle expand state of specified node
         toggleNode: function(index) {
-           
+
            var elem = this.getElementByIndex(index);
            if (!elem) return;
-           
+
            console.log('Toggle element', elem._name)
-           
+
            if (elem._expanded) {
               delete elem._expanded;
-              delete elem._childs;
+              delete elem._childs; // TODO: for the future keep childs but make request if expand once again
 
               // close folder - reassign shifts
               this.reset_nodes = true;
               this.scanShifts();
-              
+
               return true;
-              
+
            } else if (elem.type === "folder") {
-              
+
               elem._expanded = true;
               // structure is changing but not immediately
-              
+
               return true;
-              
+
            } else {
               // nothing to do
               return;
            }
-           
+
            // for now - reset all existing nodes and rebuild from the beginning
            // all nodes should be created from scratch
-           
+
            // no need to update - this should be invoked from openui anyway
            //   if (this.oBinding) this.oBinding.checkUpdate(true);
         },
-        
-        
+
+
         // change sorting method, for now server supports default, "direct" and "reverse"
         changeSortOrder: function(newValue) {
            if (newValue === undefined)
@@ -346,22 +346,22 @@ sap.ui.define([
               console.error('WRONG sorting order ', newValue, 'use default');
               newValue = "";
            }
-           
+
            // ignore same value
            if (newValue === this.sortOrder)
               return;
-           
-           
+
+
            this.sortOrder = newValue;
-           
+
            // now we should request values once again
 
            this.submitRequest(this.h, "/");
-           
+
         }
 
     });
-    
+
     return hRootModel;
 
 });

--- a/webapp/model/hModel.js
+++ b/webapp/model/hModel.js
@@ -24,6 +24,8 @@ sap.ui.define([
             
             this.loadDataCounter = 0; // counter of number of nodes
             
+            this.sortOrder = "";
+            
             this.threshold = 100; // default threshold to prefetch items
             
             // submit top-level request already when construct model
@@ -64,6 +66,7 @@ sap.ui.define([
         },
 
         // submit next request to the server 
+        // now using simple HTTP requests, in ROOT websocket communication will be used
         submitRequest: function(elem, path, first, number) {
            
            if (elem._requested) return;
@@ -74,6 +77,9 @@ sap.ui.define([
            var request = "path=" + path;
            if ((first !== undefined) && (number !== undefined))
               request += "&first=" + first + "&number=" + number;
+           
+           if (this.sortOrder)
+              request += "&sort=" + this.sortOrder;
 
            // TODO: here is just HTTP request, in ROOT we will use websocket to send requests and process replies 
            jQuery.ajax({
@@ -319,6 +325,28 @@ sap.ui.define([
            
            // no need to update - this should be invoked from openui anyway
            //   if (this.oBinding) this.oBinding.checkUpdate(true);
+        },
+        
+        changeSortOrder: function(newValue) {
+           if (newValue === undefined)
+               newValue = this.getProperty("/sortOrder") || "";
+
+           if ((newValue !== "") && (newValue !=="direct") && (newValue !== "reverse")) {
+              console.error('WRONG sorting order ', newValue, 'use default');
+              newValue = "";
+           }
+           
+           // ignore same value
+           if (newValue === this.sortOrder)
+              return;
+           
+           
+           this.sortOrder = newValue;
+           
+           // now we should request values once again
+
+           this.submitRequest(this.h, "/");
+           
         }
 
     });

--- a/webapp/model/hModel.js
+++ b/webapp/model/hModel.js
@@ -1,0 +1,144 @@
+sap.ui.define([
+    "jquery.sap.global",
+    "sap/ui/model/json/JSONModel",
+    "root/model/hListBinding"
+], function(jQuery, JSONModel, hListBinding) {
+   "use strict";
+
+    var hRootModel = JSONModel.extend("root.model.hModel", {
+
+        constructor: function(sBaseUrl) {
+            JSONModel.apply(this);
+            this._sBaseUrl = sBaseUrl;
+            this.setProperty("/", {
+                nodes: {}
+            });
+        },
+
+        bindTree: function(sPath, oContext, aFilters, mParameters, aSorters) {
+            var oBinding = new hListBinding(this, sPath, oContext, aFilters, mParameters, aSorters);
+            return oBinding;
+        },
+
+        loadEntries: function(start, end, threshold) {
+
+            return new Promise(function(resolve, reject) {
+
+                var sType = "loadEntries";
+                var sUrl = this._sBaseUrl + "?top=" + start + "&length=" + threshold; //end;
+                var sMethod = "GET";
+                
+                jQuery.ajax({
+                    url: sUrl,
+                    dataType: "json",
+                    method: sMethod
+                }).done(function(responseData, textStatus, jqXHR) {
+
+                    // update the model with the new data
+                    var data = this.getProperty("/");
+                    data.length = responseData.length || 0;
+                    responseData.nodes.forEach(function(node, index, arr) {
+                        data.nodes[node.index] = node
+                    });
+                    this.setProperty("/", data);
+                    
+                    // notify the listeners that the nodes has been loaded properly
+                    this.fireRequestCompleted({
+                        type: sType, url : sUrl, method : sMethod, success: true
+                    });
+                    
+                    // resolve the Promise
+                    resolve(data);
+                    
+                }.bind(this)).fail(function(jqXHR, textStatus, errorThrown) {
+                    
+                    // log the error for debugging to see the issue when checking the log
+                    jQuery.sap.log.error("Failed to read data! Reason: " + errorThrown);
+                    
+                    // update the model with and empty list of nodes
+                    var data = this.getProperty("/");
+                    data.length = 0;
+                    data.nodes = {};
+                    this.setProperty("/", data);
+                    
+                    // notify the listeners that the request failed and no nodes could be loaded
+                    this.fireRequestCompleted({
+                        type: sType, url : sUrl, method : sMethod,success: false, error: errorThrown
+                    });
+                    this.fireRequestFailed(errorThrown);
+                    
+                    // reject the Promise
+                    reject(errorThrown);
+                    
+                }.bind(this));
+                
+                // notify the listeners that a request has been sent 
+                this.fireRequestSent({
+                    type: sType, url : sUrl, method : sMethod
+                });
+
+            }.bind(this));
+
+        },
+
+        toggleNode: function(index) {
+
+            return new Promise(function(resolve, reject) {
+
+                var sType = "toggleNode";
+                var sUrl = this._sBaseUrl + "?toggle=" + index; //end;
+                var sMethod = "GET";
+                
+                jQuery.ajax({
+                    url: sUrl,
+                    dataType: "json",
+                    method: sMethod
+                }).done(function(responseData, textStatus, jqXHR) {
+
+                    // update the model with the new data
+                    var data = this.getProperty("/");
+                    data.length = responseData.length || 0;
+                    data.nodes = {};
+                    responseData.nodes.forEach(function(node, index, arr) {
+                        data.nodes[node.index] = node;
+                    });
+                    this.setProperty("/", data);
+                    
+                    // notify the listeners that the nodes has been loaded properly
+                    this.fireRequestCompleted({
+                        type: sType, url : sUrl, method : sMethod, success: true
+                    });
+                    
+                    // resolve the Promise
+                    resolve(data);
+                    
+                }.bind(this)).fail(function(jqXHR, textStatus, errorThrown) {
+                    
+                    // log the error for debugging to see the issue when checking the log
+                    jQuery.sap.log.error("Failed to read data! Reason: " + errorThrown);
+                    
+                    // notify the listeners that the request failed and no nodes could be loaded
+                    this.fireRequestCompleted({
+                        type: sType, url : sUrl, method : sMethod,success: false, error: errorThrown
+                    });
+                    this.fireRequestFailed(errorThrown);
+                    
+                    // reject the Promise
+                    reject(errorThrown);
+                    
+                }.bind(this));
+                
+                // notify the listeners that a request has been sent 
+                this.fireRequestSent({
+                    type: sType, url : sUrl, method : sMethod
+                });
+
+            }.bind(this));
+
+        }
+
+    });
+
+    return hRootModel;
+
+});

--- a/webapp/model/hModel.js
+++ b/webapp/model/hModel.js
@@ -174,7 +174,7 @@ sap.ui.define([
                     
                     if (remains > 0) {
                        if (!assign_shifts && args && (id < args.begin) && (id + remains >= args.begin)) {
-                          var first = Math.max(_last, last + (args.begin-id) - 10),
+                          var first = Math.max(_last, _last + (args.begin-id) - 10),
                               number = Math.min(elem._nchilds - first, 100);
                           requests.push("path=" + path + "&first=" + first + "&number=" + number);
                        }

--- a/webapp/model/hModel.js
+++ b/webapp/model/hModel.js
@@ -97,8 +97,6 @@ sap.ui.define([
            }
            
            function scan(lvl, elem, path) {
-              // path = !path ? "/" : path + "/" + elem._name;
-
               if (build_nodes) 
                  data.nodes[id] = {
                     name: elem._name,

--- a/webapp/model/hModel.js
+++ b/webapp/model/hModel.js
@@ -33,7 +33,8 @@ sap.ui.define([
         },
 
         bindTree: function(sPath, oContext, aFilters, mParameters, aSorters) {
-           Log.warning("root.model.hModel#bindTree()");
+           Log.warning("root.model.hModel#bindTree() " + sPath);
+           console.error("Do binding - where?");
            this.oBinding = new hListBinding(this, sPath, oContext, aFilters, mParameters, aSorters);
            return this.oBinding;
         },

--- a/webapp/view/Main.view.xml
+++ b/webapp/view/Main.view.xml
@@ -41,16 +41,16 @@
 								selectionBehavior="RowOnly"
 								selectionMode="Single"
 								visibleRowCountMode="Auto"
-								rows="{/nodes}">
+								rows="{browse>/nodes}">
 								<table:columns>
-									<table:Column label="Name" template="name"></table:Column>
+									<table:Column label="Name" template="browse>name"></table:Column>
 								</table:columns>
 							</table:TreeTable>
 						</content>
 						<footer>
 							<Toolbar>
 								<Label text="Sorting:" />
-								<ComboBox selectedKey="{/sortOrder}" change="sortOrderChanged">
+								<ComboBox selectedKey="{browse>/sortOrder}" change="sortOrderChanged">
                            <core:Item key="direct" text="Sorted"/>
                            <core:Item key="reverse" text="Reverse"/>
                         </ComboBox>
@@ -67,12 +67,12 @@
 								<items >
 									<TabContainerItem name="Canvas_1">
 										<content>
-											
+
 										</content>
 									</TabContainerItem>
 									<TabContainerItem name="Editor 1">
 										<content>
-											
+
 										</content>
 									</TabContainerItem>
 								</items>

--- a/webapp/view/Main.view.xml
+++ b/webapp/view/Main.view.xml
@@ -24,7 +24,7 @@
 					<Page>
 						<customHeader>
 							<OverflowToolbar>
-								<Button icon="sap-icon://sort" type="Transparent" />
+								<Button icon="sap-icon://sort" type="Transparent" press="changeSort"/>
 								<Button icon="sap-icon://filter" type="Transparent" />
 								<Button icon="sap-icon://synchronize" type="Transparent" />
 								<!-- <Label text="Draw:" /> -->

--- a/webapp/view/Main.view.xml
+++ b/webapp/view/Main.view.xml
@@ -1,6 +1,7 @@
 <mvc:View controllerName="root.controller.Main"
 		xmlns:mvc="sap.ui.core.mvc"
 		xmlns:layout="sap.ui.layout"
+      xmlns:core="sap.ui.core"
 		xmlns:table="sap.ui.table"
 		displayBlock="true"
 		xmlns="sap.m">
@@ -48,8 +49,11 @@
 						</content>
 						<footer>
 							<Toolbar>
-								<Label text="Filter:" />
-								<ComboBox />
+								<Label text="Sorting:" />
+								<ComboBox selectedKey="{/sortOrder}" change="sortOrderChanged">
+                           <core:Item key="direct" text="Sorted"/>
+                           <core:Item key="reverse" text="Reverse"/>
+                        </ComboBox>
 							</Toolbar>
 						</footer>
 					</Page>


### PR DESCRIPTION
Hi @petermuessig 

This is direction which I want to go. 
I modify your demo in the way that flat items list maintained only on client side.
Server only works with hierarchical structures and implement only ``/hierarchy`` request.

Client can request content for any folder (or subfolder). If there are too many items in folder - only "visible" items are requested (those are in scrolled area). Maximal 100 items from each folder is requested.

For any folder server can configure "_expanded" state. If client see such state - it automatically loads content of this folder. Later one can improve logic and load subfolder content only if it close to scrolled area.

Simple sorting implemented on server. It can resort items before send to the client.